### PR TITLE
Dependency Injection

### DIFF
--- a/lib/martyBuilder.js
+++ b/lib/martyBuilder.js
@@ -11,6 +11,9 @@ class MartyBuilder {
     this._marty[id] = clazz;
     this._marty.registry.addClass(id, clazz);
   }
+  registerProperty(id, description) {
+    Object.defineProperty(this._marty, id, description);
+  }
   register(id, value) {
     this._marty[id] = value;
   }

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -5,6 +5,7 @@ var warnings = {
   invokeConstant: true,
   reservedFunction: true,
   cannotFindContext: true,
+  martyIsASingelton: true,
   classDoesNotHaveAnId: true,
   stateIsNullOrUndefined: true,
   callingResolverOnServer: true,

--- a/main.js
+++ b/main.js
@@ -17,6 +17,22 @@ module.exports = function (marty) {
   marty.register('diagnostics', diagnostics);
   marty.register('createStateSource', createStateSource);
 
+  marty.registerProperty('isASingleton', {
+    get() {
+      return !!this.__isASingleton;
+    },
+    set(value) {
+      if (this.warnings.martyIsASingleton) {
+        logger.warn(
+          'Warning: Marty will no longer be a singleton in future releases ' +
+          'http://martyjs.org/guides/marty-is-a-singelton.html'
+        ).
+
+        this.__isASingleton = value;
+      }
+    }
+  });
+
   _.each(environment, function (value, key) {
     marty.register(key, value);
   });


### PR DESCRIPTION
This is a revised plan after feedback and discussions with @dariocravero @taion

**Core Types == [Action Creators, Queries, Stores, State Sources]**

There is a new type called Application which will replace Marty's singleton. Each instance of Application will have its own dispatcher. When you instantiate the application you create instances of all types you need. Core types expect the application to passed into their constructor.

```js
class Application extends Marty.Application {
  constructor() {
    super()

    this.userQueries = new UserQueries(this);
    this.userActions = new UserActions(this);
    this.userStore = new UserStore(this, new Something());
  }
}

var app = new Application();

app.dispatcher.register(action => {
  console.log('Action dispatched', action)
});

app.userActions.deleteUser(123);
```

You will be able to access the application instance within core types via ``this.app``

```js
class UserStore extends Marty.Store {
  constructor(app, something) {
    super(app);

    this.something = something;
  }

  getUser(id) {
    return this.fetch({
      id: id,
      remotely() {
        return this.app.userQueries.getUser(id);
      }
    });
  }
}
```

To access the application within components the application instance will be passed down via react context's. To allow this the Marty applications have ``bindTo(Component)`` which wraps the component with a component that passes the the context down.

```js
var User = app.bindTo(require('./component/user'));

React.render(<User />, ...)

class User extends React.Component {
  deleteUser() {
    this.context.app.userActions.deleteUser(123)
  }
}

// Convenience method for { app: React.PropTypes.instanceOf(Marty.Application) }
User.contextTypes = Marty.contextTypes;
```

Testing becomes much easier now

```js
new UserStore({
    app: {
        userQueries: {
            getUser: sinon.stub().returns(...)
        }
    }
})

MartyTestUtils.mockApplication(Component, {
  userActions: {
    createUser: sinon.spy()
  }
})
```

All [state functions](http://martyjs.org/api/top-level-api/#state) will be moved onto the application instance. [dehyrdation](http://martyjs.org/api/top-level-api/#dehydrate) and [rehydration](http://martyjs.org/api/top-level-api/#rehydrate) will look at all stores that have been added to the application.

To support migration from v0.9 we will have ``Marty.isASingleton``. When ``Marty.isASingleton = true`` it will have the same behaviour as v0.9. When false (default)

* It will not maintain an internal registry (``Marty.registry`` will return undefined)
* ``Marty.register`` will throw an error saying you should use applications instead
* ``Marty.create*`` (e.g. ``Marty.createStore``) will return types instead of instances
* ``Marty.renderToString`` will behave differently

```js
// v0.9 || v0.10 && Marty.isASingleton == true

Marty.renderToString({
  type: require('./views/user'),
  context: Marty.createContext(),
  props: { bar: 'bar' },
  timeout: 1000
}).then(res => console.log(res.html));


// v0.10 && Marty.isASingleton == false

var app = new Marty.Application();
var User = app.bindTo(require('./views/user'));

Marty.renderToString(<User bar='bar' />, { timeout: 1000 })
     .then(res => console.log(res.html))
```

**Things we'd like to do in the future**

``Marty.Application`` has ``register(id, clazz)`` that allows to you decentralise registration if you like.

```js
var Application = require('marty').Application;

Application.register('userQueries', UserQueries);

var app = new Application();

app.userQueries.getUser()
```

**Motivations for this design**

The goals are to

* Make it easier to manage multiple instances of Marty easily in an idiomatic way
* Simplify how Marty applications are built with no magic to make it easier to understand whats happening

We are going to move away from singletons altogether. Testing is more difficult and if they want to start doing isomorphism then you have to re-write all your code. The only argument for them is simplicity but I think the small amount of added complexity brings significant more value.

Having to register all types up front is a contentious one.

Arguments against it:

* It requires to remember to add/remove the instance from the application class
* If you forget to remove it then it can lead to redundant code being required in.

Arguments for it:

* You only have to know about stores up front. However it will be confusing to have one strategy for registering stores and another for all other types
* Adding/removing stores/queries/action creators is not something that happens very often. I don't see the need to optimize for a situation that might happen once or twice a month
* You can do automatic registration using things like [bulkify](https://github.com/substack/bulkify) if you want. You could also split registration into multiple files (e.g. ./stores/index.js, ./queries/index.js) so you don't have one giant file
* This is how [alt](http://alt.js.org/) and [flummox](http://acdlite.github.io/flummox) do it and no one seems to be complaining

**Deprecations**

* ``Registry``
* ``Context``
* ``Marty.createContext``
* ``Marty.createInstance``
* ``Marty.register``
* ``Marty.registry``
* ``Marty.dispatcher``

**Tasks**

* [x] Add `Marty.isASingleton` to switch Marty's behaviour
  * [ ] Add documentation http://martyjs.org/guides/marty-is-a-singelton.html
* [ ] Work out how best to do registration